### PR TITLE
Make compatible with ReVanced

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ docker buildx build --load -t 1337kavin/sponsorblock-mirror .
 
 ## Troubleshooting
 
-* If the linker complains about a missing `-lpq`, make sure you have the PostgresQL development libraries, which may be in a `libpq-dev` package or your distribution's equivalent.
+* If the linker complains about a missing `-lpq`, make sure you have the PostgreSQL development libraries, which may be in a `libpq-dev` package or your distribution's equivalent.
 
 * If Docker complains that `the --mount option requires BuildKit`, make sure you are building with `docker buildx build` and not `docker build`.
 

--- a/README.md
+++ b/README.md
@@ -47,14 +47,6 @@ docker buildx build --load -t 1337kavin/sponsorblock-mirror .
 
 * If Docker complains that `the --mount option requires BuildKit`, make sure you are building with `docker buildx build` and not `docker build`.
 
-* If `docker compose` complains like this:
-  ```
-  ERROR: The Compose file './docker-compose.yml' is invalid because:
-  Unsupported config option for volumes: 'postgres_data'
-  Unsupported config option for services: 'sb-mirror'
-  ```
-  then you are using an old version of `docker compose` which does not fully support the Compose Specification and [requires a 'version' key to differentiate the file from a V1 compose file](https://docs.docker.com/compose/compose-file/#version-top-level-element). Try appending `version: "3"` to the file.
-
 * To access the PosgresQL database directly, you can `docker exec -ti postgres-sb-mirror bash -c 'psql $POSTGRES_DB $POSTGRES_USER'`.
 
 * Requests for videos not in the database are forwarded to `https://sponsor.ajay.app/`, which may be down or malfunctioning. A response of the string `Internal Server Error` is likely to be from there, rather than from this application.

--- a/README.md
+++ b/README.md
@@ -13,3 +13,51 @@ It also uses [sb-mirror](https://github.com/mchangrh/sb-mirror) for mirroring th
 Feel free to add your instance to this list by making a pull request.
 
 You can also configure Piped-Backend to use your mirror by changing the `SPONSORBLOCK_SERVERS` configuration value.
+
+## Compatibility
+
+This implementation does not implement the full SponsorBlock server API. It supports hash-based queries to `/api/skipSegments/<hash>`, with optional `categories` parameter, and queries to `/api/skipSegments` with required `videoID` and optional `categories` parameters.
+
+The browser extension works with only the hash-based query endpoint, but other clients, such as the one in ReVanced, require the video ID endpoint, and additionally query `/api/userInfo` and `/api/isUserVip`. Right now there are stub implementations for these. ReVanced had not yet been verified as compatible.
+
+## Building
+
+To make a local release build, use `cargo build --release`. This will produce a binary in `target/release/sponsorblock-mirror`.
+
+To make a Docker container, you need to do a BuildKit Docker build, not a normal Docker build. Make sure you have `buildx` available in your Docker, and run:
+```bash
+docker buildx build --load -t 1337kavin/sponsorblock-mirror .
+```
+
+## Using with Docker Compose
+
+To run the server under Docker Compose, run:
+
+```
+docker compose up
+```
+
+This starts the API server, a database, and a mirroring service to download the SponsorBlock data from the `sponsorblock.kavin.rocks` mirror and keep it up to date.
+
+The API will be available on `http://localhost:8000`. For example, you can try `http://localhost:8000/api/skipSegments/aabf` or `http://localhost:8000/api/skipSegments?videoID=eQ_8F4nzyiw`. **It will take a few minutes at least for the database to download and import,** so these will not return data on the first run.
+
+## Troubleshooting
+
+* If the linker complains about a missing `-lpq`, make sure you have the PostgresQL development libraries, which may be in a `libpq-dev` package or your distribution's equivalent.
+
+* If Docker complains that `the --mount option requires BuildKit`, make sure you are building with `docker buildx build` and not `docker build`.
+
+* If `docker compose` complains like this:
+  ```
+  ERROR: The Compose file './docker-compose.yml' is invalid because:
+  Unsupported config option for volumes: 'postgres_data'
+  Unsupported config option for services: 'sb-mirror'
+  ```
+  then you are using an old version of `docker compose` which does not fully support the Compose Specification and [requires a 'version' key to differentiate the file from a V1 compose file](https://docs.docker.com/compose/compose-file/#version-top-level-element). Try appending `version: "3"` to the file.
+  
+* On the first run of `docker compose`, even after the database files are downloaded, you may see errors like `could not open file "/mirror/sponsorTimes.csv" for reading: Permission denied`. Assuming the permissions on the `.csv` files are actually set to be world-readable, you might be able to fix this by stopping and restarting `docker compose`.
+
+* To access the PosgresQL database directly, you can `docker exec -ti postgres-sb-mirror bash -c 'psql $POSTGRES_DB $POSTGRES_USER'`.
+
+* Requests for videos not in the database are forwarded to `https://sponsor.ajay.app/`, which may be down or malfunctioning. A response of the string `Internal Server Error` is likely to be from there, rather than from this application.
+

--- a/README.md
+++ b/README.md
@@ -20,15 +20,6 @@ This implementation does not implement the full SponsorBlock server API. It supp
 
 The browser extension works with only the hash-based query endpoint, but other clients, such as the one in ReVanced, require the video ID endpoint, and additionally query `/api/userInfo` and `/api/isUserVip`. Right now there are stub implementations for these. ReVanced had not yet been verified as compatible.
 
-## Building
-
-To make a local release build, use `cargo build --release`. This will produce a binary in `target/release/sponsorblock-mirror`.
-
-To make a Docker container, you need to do a BuildKit Docker build, not a normal Docker build. Make sure you have `buildx` available in your Docker, and run:
-```bash
-docker buildx build --load -t 1337kavin/sponsorblock-mirror .
-```
-
 ## Using with Docker Compose
 
 To run the server under Docker Compose, run:
@@ -40,6 +31,15 @@ docker compose up
 This starts the API server, a database, and a mirroring service to download the SponsorBlock data from the `sponsorblock.kavin.rocks` mirror and keep it up to date.
 
 The API will be available on `http://localhost:8000`. For example, you can try `http://localhost:8000/api/skipSegments/aabf` or `http://localhost:8000/api/skipSegments?videoID=eQ_8F4nzyiw`. **It will take a few minutes at least for the database to download and import,** so these will not return data on the first run.
+
+## Building
+
+To make a local release build, use `cargo build --release`. This will produce a binary in `target/release/sponsorblock-mirror`.
+
+To make a Docker container, you need to do a BuildKit Docker build, not a normal Docker build. Make sure you have `buildx` available in your Docker, and run:
+```bash
+docker buildx build --load -t 1337kavin/sponsorblock-mirror .
+```
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,6 @@ The API will be available on `http://localhost:8000`. For example, you can try `
   ```
   then you are using an old version of `docker compose` which does not fully support the Compose Specification and [requires a 'version' key to differentiate the file from a V1 compose file](https://docs.docker.com/compose/compose-file/#version-top-level-element). Try appending `version: "3"` to the file.
 
-* On the first run of `docker compose`, even after the database files are downloaded, you may see errors like `could not open file "/mirror/sponsorTimes.csv" for reading: Permission denied`. Assuming the permissions on the `.csv` files are actually set to be world-readable, you might be able to fix this by stopping and restarting `docker compose`.
-
 * To access the PosgresQL database directly, you can `docker exec -ti postgres-sb-mirror bash -c 'psql $POSTGRES_DB $POSTGRES_USER'`.
 
 * Requests for videos not in the database are forwarded to `https://sponsor.ajay.app/`, which may be down or malfunctioning. A response of the string `Internal Server Error` is likely to be from there, rather than from this application.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The API will be available on `http://localhost:8000`. For example, you can try `
   Unsupported config option for services: 'sb-mirror'
   ```
   then you are using an old version of `docker compose` which does not fully support the Compose Specification and [requires a 'version' key to differentiate the file from a V1 compose file](https://docs.docker.com/compose/compose-file/#version-top-level-element). Try appending `version: "3"` to the file.
-  
+
 * On the first run of `docker compose`, even after the database files are downloaded, you may see errors like `could not open file "/mirror/sponsorTimes.csv" for reading: Permission denied`. Assuming the permissions on the `.csv` files are actually set to be world-readable, you might be able to fix this by stopping and restarting `docker compose`.
 
 * To access the PosgresQL database directly, you can `docker exec -ti postgres-sb-mirror bash -c 'psql $POSTGRES_DB $POSTGRES_USER'`.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ docker buildx build --load -t 1337kavin/sponsorblock-mirror .
 
 * If Docker complains that `the --mount option requires BuildKit`, make sure you are building with `docker buildx build` and not `docker build`.
 
-* To access the PosgresQL database directly, you can `docker exec -ti postgres-sb-mirror bash -c 'psql $POSTGRES_DB $POSTGRES_USER'`.
+* To access the PostgreSQL database directly, you can `docker exec -ti postgres-sb-mirror bash -c 'psql $POSTGRES_DB $POSTGRES_USER'`.
 
 * Requests for videos not in the database are forwarded to `https://sponsor.ajay.app/`, which may be down or malfunctioning. A response of the string `Internal Server Error` is likely to be from there, rather than from this application.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+version: "3"
+
 services:
   sb-mirror:
     image: mchangrh/sb-mirror:latest
@@ -39,4 +41,3 @@ services:
       - sb-mirror
 volumes:
   postgres_data: null
-version: "3"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,3 +39,4 @@ services:
       - sb-mirror
 volumes:
   postgres_data: null
+version: "3"

--- a/migrations/2022-10-30-175428_create_video_id_index/down.sql
+++ b/migrations/2022-10-30-175428_create_video_id_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS "sponsor_video_id_idx";

--- a/migrations/2022-10-30-175428_create_video_id_index/up.sql
+++ b/migrations/2022-10-30-175428_create_video_id_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX sponsor_video_id_idx ON "sponsorTimes"("videoID");

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use tokio::time::interval;
 
 use structs::{Segment, Sponsor};
 
-use crate::routes::skip_segments;
+use crate::routes::{skip_segments, skip_segments_by_id, fake_is_user_vip, fake_user_info};
 
 mod models;
 mod routes;
@@ -120,5 +120,5 @@ fn rocket() -> Rocket<Build> {
             })
         })
         ).attach(CORS)
-        .mount("/", routes![skip_segments])
+        .mount("/", routes![skip_segments, skip_segments_by_id, fake_is_user_vip, fake_user_info])
 }

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -77,8 +77,9 @@ pub async fn skip_segments_by_id(
     db: Db,
 ) -> content::RawJson<String> {
 
-    if videoID.is_empty()  {
-        return content::RawJson("videoID is missing".to_string());
+    // Check if ID matches ID regex
+    if !ID_RE.is_match(&videoID) {
+        return content::RawJson("videoID does not match format requirements".to_string());
     }
 
     let sponsors = find_skip_segments(VideoName::ByID(videoID.clone()), categories, db).await;

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -48,26 +48,25 @@ pub async fn skip_segments(
         return content::RawJson("Hash prefix does not match format requirements.".to_string());
     }
 
-    let search_result = find_skip_segments(VideoName::ByHashPrefix(hash.clone()), categories, db).await;
+    let sponsors = find_skip_segments(VideoName::ByHashPrefix(hash.clone()), categories, db).await;
     
-    match search_result {
-        Some(segments) => return segments,
-        None => {
-            // Fall back to central Sponsorblock server
-            let resp = reqwest::get(format!(
-                "https://sponsor.ajay.app/api/skipSegments/{}?categories={}",
-                hash,
-                categories.unwrap_or("[]"),
-            ))
-                .await
-                .unwrap()
-                .text()
-                .await
-                .unwrap();
+    if sponsors.is_empty() {
+        // Fall back to central Sponsorblock server
+        let resp = reqwest::get(format!(
+            "https://sponsor.ajay.app/api/skipSegments/{}?categories={}",
+            hash,
+            categories.unwrap_or("[]"),
+        ))
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap();
 
-            return content::RawJson(resp);
-        }
+        return content::RawJson(resp);
     }
+    
+    return content::RawJson(serde_json::to_string(&sponsors).unwrap());
 }
 
 #[get("/api/skipSegments?<videoID>&<categories>")]
@@ -82,40 +81,39 @@ pub async fn skip_segments_by_id(
         return content::RawJson("videoID is missing".to_string());
     }
 
-    let search_result = find_skip_segments(VideoName::ByID(videoID.clone()), categories, db).await;
+    let sponsors = find_skip_segments(VideoName::ByID(videoID.clone()), categories, db).await;
     
-    match search_result {
-        Some(segments) => return segments,
-        None => {
-            // Fall back to central Sponsorblock server
-            let resp = reqwest::get(format!(
-                "https://sponsor.ajay.app/api/skipSegments?videoID={}&categories={}",
-                videoID,
-                categories.unwrap_or("[]"),
-            ))
-                .await
-                .unwrap()
-                .text()
-                .await
-                .unwrap();
+    if sponsors.is_empty() {
+        // Fall back to central Sponsorblock server
+        let resp = reqwest::get(format!(
+            "https://sponsor.ajay.app/api/skipSegments?videoID={}&categories={}",
+            videoID,
+            categories.unwrap_or("[]"),
+        ))
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap();
 
-            return content::RawJson(resp);
-        }
+        return content::RawJson(resp);
     }
+    
+    // Doing a lookup by video ID should return only one Sponsor object with
+    // one list of segments. We need to return just the list of segments.
+    return content::RawJson(serde_json::to_string(&sponsors[0].segments).unwrap());
 }
 
 async fn find_skip_segments(
     name: VideoName,
     categories: Option<&str>,
     db: Db,
-) -> Option<content::RawJson<String>> {
+) -> Vec<Sponsor> {
 
     let cat: Vec<String> = serde_json::from_str(categories.unwrap_or("[\"sponsor\"]")).unwrap();
 
     if cat.is_empty() {
-        return Some(content::RawJson(
-            "[]".to_string(),
-        ));
+        return Vec::new(); 
     }
     
     let results: Vec<SponsorTime> = db.run(move |conn| {
@@ -196,13 +194,8 @@ async fn find_skip_segments(
     for sponsor in sponsors.values_mut() {
         sponsor.segments.sort_by(|a, b| a.partial_cmp(b).unwrap());
     }
-
-    if !sponsors.is_empty() {
-        let sponsors: Vec<&Sponsor> = sponsors.values().collect();
-        return Some(content::RawJson(serde_json::to_string(&sponsors).unwrap()));
-    }
-
-    return None;
+    
+    return sponsors.into_values().collect();
 }
 
 fn similar_segments(segment: &Segment, hash: &str, segments: &Vec<SponsorTime>) -> Vec<Segment> {
@@ -272,9 +265,9 @@ fn best_segment(segments: &Vec<Segment>) -> Segment {
     best_segment
 }
 
-// We might need some more routes to support ReVanced. These are faked for now.
-// Sadly not even these are sufficient to make it work for me, maybe it is just
-// broken?
+// These additional routes are faked to protect ReVanced from seeing errors. We
+// don't *need* to do this to support ReVanced, but it gets rid of the
+// perpetual "Loading..." in the settings.
 
 // This would take a userID
 #[get("/api/isUserVIP")]

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -49,7 +49,7 @@ pub async fn skip_segments(
     }
 
     let sponsors = find_skip_segments(VideoName::ByHashPrefix(hash.clone()), categories, db).await;
-    
+
     if sponsors.is_empty() {
         // Fall back to central Sponsorblock server
         let resp = reqwest::get(format!(
@@ -65,7 +65,7 @@ pub async fn skip_segments(
 
         return content::RawJson(resp);
     }
-    
+
     return content::RawJson(serde_json::to_string(&sponsors).unwrap());
 }
 
@@ -82,7 +82,7 @@ pub async fn skip_segments_by_id(
     }
 
     let sponsors = find_skip_segments(VideoName::ByID(videoID.clone()), categories, db).await;
-    
+
     if sponsors.is_empty() {
         // Fall back to central Sponsorblock server
         let resp = reqwest::get(format!(
@@ -98,7 +98,7 @@ pub async fn skip_segments_by_id(
 
         return content::RawJson(resp);
     }
-    
+
     // Doing a lookup by video ID should return only one Sponsor object with
     // one list of segments. We need to return just the list of segments.
     return content::RawJson(serde_json::to_string(&sponsors[0].segments).unwrap());
@@ -113,16 +113,16 @@ async fn find_skip_segments(
     let cat: Vec<String> = serde_json::from_str(categories.unwrap_or("[\"sponsor\"]")).unwrap();
 
     if cat.is_empty() {
-        return Vec::new(); 
+        return Vec::new();
     }
-    
+
     let results: Vec<SponsorTime> = db.run(move |conn| {
         let base_filter = sponsorTimes
             .filter(shadowHidden.eq(0))
             .filter(hidden.eq(0))
             .filter(votes.ge(0))
             .filter(category.eq_any(cat)); // We know cat isn't empty at this point
-        
+
         let queried = match name {
             VideoName::ByHashPrefix(hash_prefix) => {
                 base_filter
@@ -194,7 +194,7 @@ async fn find_skip_segments(
     for sponsor in sponsors.values_mut() {
         sponsor.segments.sort_by(|a, b| a.partial_cmp(b).unwrap());
     }
-    
+
     return sponsors.into_values().collect();
 }
 

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -55,7 +55,7 @@ pub async fn skip_segments(
         let resp = reqwest::get(format!(
             "https://sponsor.ajay.app/api/skipSegments/{}?categories={}",
             hash,
-            categories.unwrap_or("[]"),
+            categories.unwrap_or("[\"sponsor\"]"),
         ))
             .await
             .unwrap()
@@ -89,7 +89,7 @@ pub async fn skip_segments_by_id(
         let resp = reqwest::get(format!(
             "https://sponsor.ajay.app/api/skipSegments?videoID={}&categories={}",
             videoID,
-            categories.unwrap_or("[]"),
+            categories.unwrap_or("[\"sponsor\"]"),
         ))
             .await
             .unwrap()
@@ -154,17 +154,7 @@ async fn find_skip_segments(
             })
         };
 
-        let segment = Segment {
-            uuid: result.uuid.clone(),
-            action_type: result.action_type.clone(),
-            category: result.category.clone(),
-            description: result.description.clone(),
-            locked: result.locked,
-            segment: vec![result.start_time, result.end_time],
-            user_id: result.user_id.clone(),
-            video_duration: result.video_duration,
-            votes: result.votes,
-        };
+        let segment = build_segment(result);
 
         let hash = result.hashed_video_id.clone();
 
@@ -214,17 +204,7 @@ fn similar_segments(segment: &Segment, hash: &str, segments: &Vec<SponsorTime>) 
         let is_similar = is_overlap(segment, &seg.category, &seg.action_type, seg.start_time, seg.end_time);
 
         if is_similar {
-            similar_segments.push(Segment {
-                uuid: seg.uuid.clone(),
-                action_type: seg.action_type.clone(),
-                category: seg.category.clone(),
-                description: seg.description.clone(),
-                locked: seg.locked,
-                segment: vec![seg.start_time, seg.end_time],
-                user_id: seg.user_id.clone(),
-                video_duration: seg.video_duration,
-                votes: seg.votes,
-            });
+            similar_segments.push(build_segment(seg));
         }
     }
 
@@ -264,6 +244,20 @@ fn best_segment(segments: &Vec<Segment>) -> Segment {
     }
 
     best_segment
+}
+
+fn build_segment (sponsor_time: &SponsorTime) -> Segment {
+    Segment {
+        uuid: sponsor_time.uuid.clone(),
+        action_type: sponsor_time.action_type.clone(),
+        category: sponsor_time.category.clone(),
+        description: sponsor_time.description.clone(),
+        locked: sponsor_time.locked,
+        segment: vec![sponsor_time.start_time, sponsor_time.end_time],
+        user_id: sponsor_time.user_id.clone(),
+        video_duration: sponsor_time.video_duration,
+        votes: sponsor_time.votes,
+    }
 }
 
 // These additional routes are faked to protect ReVanced from seeing errors. We

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,7 +1,6 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
-    #[allow(non_snake_case)]
     sponsorTimes (UUID) {
         videoID -> Text,
         startTime -> Float4,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,6 +1,7 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
+    #[allow(non_snake_case)]
     sponsorTimes (UUID) {
         videoID -> Text,
         startTime -> Float4,


### PR DESCRIPTION
This makes this server implementation compatible with ReVanced's SponsorBlock integration, by [implementing the `/api/kipSegments?videoID=` endpoint](https://wiki.sponsor.ajay.app/w/API_Docs#GET_/api/skipSegments) which that client uses.

I had to reorganize the code a little to break out most of the query logic into a function that both methods can use.

I also added stubs for a couple of user-related endpoints that ReVanced queries, which I don't think are strictly necessary.

Finally, I documented some setup steps and problems that I had to go through in the README, in hopes of helping people to get this running.