### PR TITLE
Remove sb.theairplan.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ It also uses [sb-mirror](https://github.com/mchangrh/sb-mirror) for mirroring th
 
 -   [sponsorblock.kavin.rocks](https://sponsorblock.kavin.rocks) - 🇩🇪 (main instance)
 -   [sponsorblock.gleesh.net](https://sponsorblock.gleesh.net) - 🇩🇪
--   [sb.theairplan.com](https://sb.theairplan.com) - 🇺🇸
 -   [sponsorblock.2255.me](https://sponsorblock.2255.me) - 🇵🇱
 -   [sponsorblock.hostux.net](https://sponsorblock.hostux.net) - :fr:
 


### PR DESCRIPTION
I'm no longer hosting a copy of the mirror on this server. 